### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog-synthetics.yml
+++ b/.github/workflows/datadog-synthetics.yml
@@ -12,6 +12,8 @@
 # 2. Start using the action within your workflow
 
 name: Run Datadog Synthetic tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/8](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/8)

To fix this issue, add a `permissions` block to restrict the GITHUB_TOKEN permissions to the minimum required. For most workflows that simply check out code and run third-party actions (as seen here), `contents: read` is adequate. Add the following block either at the workflow root (directly under `name: ...` and before `on:`) or under the specific job definition. Adding it at the workflow root will apply it to all jobs in this workflow. No extra imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
