### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/7](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/7)

The optimal fix is to add a `permissions` block to the workflow to restrict the job's permissions to only what's required. Since this CI workflow only runs checkout and test/build steps, it does not appear to require write permissions to anything—meaning `contents: read` is sufficient (as no steps use deploy keys or create tags/releases).  
To fix, insert the following under the `name:` field at the root level (after line 4),  
```
permissions:
  contents: read
```
Alternatively, for finer granularity, it can be added under `jobs.build`, but the top-level fix is preferred for simplicity and coverage.

No other changes or imports are necessary.  

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
