### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,5 +1,8 @@
 name: NodeJS with Webpack
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/6](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/6)

To fix this problem, add a `permissions` block to restrict the default permissions granted to the workflow's GITHUB_TOKEN. The recommended minimally privileged setting is `contents: read`, which allows reading repository contents needed for checkout, without permitting write operations. Since none of the workflow's steps require write permissions, this change will not impact functionality. This can be accomplished by adding the following block either at the workflow root (before `jobs:`) so it applies to all jobs:

```yaml
permissions:
  contents: read
```

Add this block after the workflow `name:` and before `on:` in `.github/workflows/webpack.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
