### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/4](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/4)

The best way to fix the problem is to add an explicit `permissions` block at the workflow root (before the `jobs` key) to restrict what GITHUB_TOKEN can do during job execution. In this scenario, as the workflow only needs to check out code and publish to npm (using the NPM_TOKEN secret), it is sufficient to grant read access to repository contents for both jobs (`contents: read`). Add the following block right under the workflow `name:`:

```yaml
permissions:
  contents: read
```

This will ensure GITHUB_TOKEN only has read permissions for repository contents unless further permissions are explicitly needed for certain jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
