### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Grunt
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/2](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/2)

To fix the issue, add a `permissions` key to the workflow or to the specific job to restrict the GITHUB_TOKEN permissions to the minimum required. In this workflow, no steps appear to require write access (such as pushing code, making changes to issues/pull-requests, etc.), so the minimal recommended configuration is `contents: read`. This means editing `.github/workflows/npm-grunt.yml` to insert a `permissions: contents: read` block either at the workflow/root level (directly after `name: ...`), so it applies to all jobs (since only one job exists), or at the job level directly under `runs-on`. Placing it at the workflow level is preferred if no jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
