### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Gulp
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/1](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/1)

The best way to fix the problem is to add an explicit `permissions` block granting only the minimum access required for the job. Since this workflow installs dependencies and builds the code, it only needs read access to repository contents for code checkout. The `permissions` block can be set directly at the job level (for `build`) or at the workflow root (to apply to all jobs). To align with the CodeQL suggestion and the principle of least privilege, add the following just below the workflow `name:` (line 2):  
```yaml
permissions:
  contents: read
```  
This ensures no job in the workflow will inadvertently have broader permissions than necessary. No imports, methods, variable definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
