### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/3](https://github.com/santiagourdaneta/lingua-magica-landing-page/security/code-scanning/3)

To fix the problem, we should add a `permissions` block to the `build` job with the minimal privileges needed. Generally, jobs that only check out code, install dependencies, and run tests require no more than `contents: read` (the ability to fetch code from the repository). The `build` job does not need write permissions. Therefore, add:

```yaml
permissions:
  contents: read
```

as a sibling to `runs-on` within the `build` job block (indented appropriately). No other files require changes, and no functionality is altered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
